### PR TITLE
train: Return MLflow tracking information

### DIFF
--- a/app/api/routers/evaluation.py
+++ b/app/api/routers/evaluation.py
@@ -57,11 +57,26 @@ async def get_evaluation_with_trainer_export(request: Request,
     data_file.flush()
     data_file.seek(0)
     evaluation_id = tracking_id or str(uuid.uuid4())
-    evaluation_accepted = model_service.train_supervised(data_file, 0, sys.maxsize, evaluation_id, ",".join(file_names))
+    evaluation_accepted, experiment_id, run_id = model_service.train_supervised(
+        data_file, 0, sys.maxsize, evaluation_id, ",".join(file_names)
+    )
     if evaluation_accepted:
-        return JSONResponse(content={"message": "Your evaluation started successfully.", "evaluation_id": evaluation_id}, status_code=HTTP_202_ACCEPTED)
+        return JSONResponse(
+            content={
+                "message": "Your evaluation started successfully.",
+                "evaluation_id": evaluation_id,
+                "experiment_id": experiment_id,
+                "run_id": run_id,
+            }, status_code=HTTP_202_ACCEPTED
+        )
     else:
-        return JSONResponse(content={"message": "Another training or evaluation on this model is still active. Please retry later."}, status_code=HTTP_503_SERVICE_UNAVAILABLE)
+        return JSONResponse(
+            content={
+                "message": "Another training or evaluation on this model is still active. Please retry later.",
+                "experiment_id": experiment_id,
+                "run_id": run_id,
+            }, status_code=HTTP_503_SERVICE_UNAVAILABLE
+        )
 
 
 @router.post("/sanity-check",

--- a/app/api/routers/metacat_training.py
+++ b/app/api/routers/metacat_training.py
@@ -2,7 +2,7 @@ import tempfile
 import uuid
 import json
 import logging
-from typing import List, Union
+from typing import List, Tuple, Union
 from typing_extensions import Annotated
 
 from fastapi import APIRouter, Depends, UploadFile, Query, Request, File
@@ -53,7 +53,7 @@ async def train_metacat(request: Request,
     data_file.seek(0)
     training_id = tracking_id or str(uuid.uuid4())
     try:
-        training_accepted = model_service.train_metacat(data_file,
+        training_response = model_service.train_metacat(data_file,
                                                         epochs,
                                                         log_frequency,
                                                         training_id,
@@ -65,13 +65,27 @@ async def train_metacat(request: Request,
         for file in files:
             file.close()
 
-    return _get_training_response(training_accepted, training_id)
+    return _get_training_response(training_response, training_id)
 
 
-def _get_training_response(training_accepted: bool, training_id: str) -> JSONResponse:
+def _get_training_response(training_response: Tuple[bool, str, str], training_id: str) -> JSONResponse:
+    training_accepted, experiment_id, run_id = training_response
     if training_accepted:
         logger.debug("Training accepted with ID: %s", training_id)
-        return JSONResponse(content={"message": "Your training started successfully.", "training_id": training_id}, status_code=HTTP_202_ACCEPTED)
+        return JSONResponse(
+            content={
+                "message": "Your training started successfully.",
+                "training_id": training_id,
+                "experiment_id": experiment_id,
+                "run_id": run_id,
+            }, status_code=HTTP_202_ACCEPTED
+        )
     else:
         logger.debug("Training refused due to another active training or evaluation on this model")
-        return JSONResponse(content={"message": "Another training or evaluation on this model is still active. Please retry your training later."}, status_code=HTTP_503_SERVICE_UNAVAILABLE)
+        return JSONResponse(
+            content={
+                "message": "Another training or evaluation on this model is still active. Please retry your training later.",
+                "experiment_id": experiment_id,
+                "run_id": run_id,
+            }, status_code=HTTP_503_SERVICE_UNAVAILABLE
+        )

--- a/app/api/routers/supervised_training.py
+++ b/app/api/routers/supervised_training.py
@@ -2,7 +2,7 @@ import tempfile
 import uuid
 import json
 import logging
-from typing import List, Union
+from typing import List, Tuple, Union
 from typing_extensions import Annotated
 
 from fastapi import APIRouter, Depends, UploadFile, Query, Request, File, Form
@@ -55,7 +55,7 @@ async def train_supervised(request: Request,
     data_file.seek(0)
     training_id = tracking_id or str(uuid.uuid4())
     try:
-        training_accepted = model_service.train_supervised(data_file,
+        training_response = model_service.train_supervised(data_file,
                                                            epochs,
                                                            log_frequency,
                                                            training_id,
@@ -69,13 +69,27 @@ async def train_supervised(request: Request,
         for file in files:
             file.close()
 
-    return _get_training_response(training_accepted, training_id)
+    return _get_training_response(training_response, training_id)
 
 
-def _get_training_response(training_accepted: bool, training_id: str) -> JSONResponse:
+def _get_training_response(training_response: Tuple[bool, str, str], training_id: str) -> JSONResponse:
+    training_accepted, experiment_id, run_id = training_response
     if training_accepted:
         logger.debug("Training accepted with ID: %s", training_id)
-        return JSONResponse(content={"message": "Your training started successfully.", "training_id": training_id}, status_code=HTTP_202_ACCEPTED)
+        return JSONResponse(
+            content={
+                "message": "Your training started successfully.",
+                "training_id": training_id,
+                "experiment_id": experiment_id,
+                "run_id": run_id,
+            }, status_code=HTTP_202_ACCEPTED
+        )
     else:
         logger.debug("Training refused due to another active training or evaluation on this model")
-        return JSONResponse(content={"message": "Another training or evaluation on this model is still active. Please retry your training later."}, status_code=HTTP_503_SERVICE_UNAVAILABLE)
+        return JSONResponse(
+            content={
+                "message": "Another training or evaluation on this model is still active. Please retry your training later.",
+                "experiment_id": experiment_id,
+                "run_id": run_id,
+            }, status_code=HTTP_503_SERVICE_UNAVAILABLE
+        )

--- a/app/model_services/base.py
+++ b/app/model_services/base.py
@@ -56,11 +56,11 @@ class AbstractModelService(ABC):
     def init_model(self) -> None:
         raise NotImplementedError
 
-    def train_supervised(self, *args: Tuple, **kwargs: Dict[str, Any]) -> bool:
+    def train_supervised(self, *args: Tuple, **kwargs: Dict[str, Any]) -> Tuple[bool, str, str]:
         raise NotImplementedError
 
-    def train_unsupervised(self, *args: Tuple, **kwargs: Dict[str, Any]) -> bool:
+    def train_unsupervised(self, *args: Tuple, **kwargs: Dict[str, Any]) -> Tuple[bool, str, str]:
         raise NotImplementedError
 
-    def train_metacat(self, *args: Tuple, **kwargs: Dict[str, Any]) -> bool:
+    def train_metacat(self, *args: Tuple, **kwargs: Dict[str, Any]) -> Tuple[bool, str, str]:
         raise NotImplementedError

--- a/app/model_services/huggingface_ner_model.py
+++ b/app/model_services/huggingface_ner_model.py
@@ -156,7 +156,7 @@ class HuggingFaceNerModel(AbstractModelService):
                          raw_data_files: Optional[List[TextIO]] = None,
                          description: Optional[str] = None,
                          synchronised: bool = False,
-                         **hyperparams: Dict[str, Any]) -> bool:
+                         **hyperparams: Dict[str, Any]) -> Tuple[bool, str, str]:
         if self._supervised_trainer is None:
             raise ConfigurationException("The supervised trainer is not enabled")
         return self._supervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)
@@ -170,7 +170,7 @@ class HuggingFaceNerModel(AbstractModelService):
                            raw_data_files: Optional[List[TextIO]] = None,
                            description: Optional[str] = None,
                            synchronised: bool = False,
-                           **hyperparams: Dict[str, Any]) -> bool:
+                           **hyperparams: Dict[str, Any]) -> Tuple[bool, str, str]:
         if self._unsupervised_trainer is None:
             raise ConfigurationException("The unsupervised trainer is not enabled")
         return self._unsupervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)

--- a/app/model_services/medcat_model.py
+++ b/app/model_services/medcat_model.py
@@ -119,7 +119,7 @@ class MedCATModel(AbstractModelService):
                          raw_data_files: Optional[List[TextIO]] = None,
                          description: Optional[str] = None,
                          synchronised: bool = False,
-                         **hyperparams: Dict[str, Any]) -> bool:
+                         **hyperparams: Dict[str, Any]) -> Tuple[bool, str, str]:
         if self._supervised_trainer is None:
             raise ConfigurationException("The supervised trainer is not enabled")
         return self._supervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)
@@ -133,7 +133,7 @@ class MedCATModel(AbstractModelService):
                            raw_data_files: Optional[List[TextIO]] = None,
                            description: Optional[str] = None,
                            synchronised: bool = False,
-                           **hyperparams: Dict[str, Any]) -> bool:
+                           **hyperparams: Dict[str, Any]) -> Tuple[bool, str, str]:
         if self._unsupervised_trainer is None:
             raise ConfigurationException("The unsupervised trainer is not enabled")
         return self._unsupervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)
@@ -147,7 +147,7 @@ class MedCATModel(AbstractModelService):
                       raw_data_files: Optional[List[TextIO]] = None,
                       description: Optional[str] = None,
                       synchronised: bool = False,
-                      **hyperparams: Dict[str, Any]) -> bool:
+                      **hyperparams: Dict[str, Any]) -> Tuple[bool, str, str]:
         if self._metacat_trainer is None:
             raise ConfigurationException("The metacat trainer is not enabled")
         return self._metacat_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)

--- a/app/model_services/medcat_model_deid.py
+++ b/app/model_services/medcat_model_deid.py
@@ -2,7 +2,7 @@ import logging
 import inspect
 import threading
 import torch
-from typing import Dict, List, TextIO, Optional, Any, final, Callable
+from typing import Dict, List, TextIO, Tuple, Optional, Any, final, Callable
 from functools import partial
 from transformers import pipeline
 from medcat.cat import CAT
@@ -147,7 +147,7 @@ class MedCATModelDeIdentification(MedCATModel):
                          raw_data_files: Optional[List[TextIO]] = None,
                          description: Optional[str] = None,
                          synchronised: bool = False,
-                         **hyperparams: Dict[str, Any]) -> bool:
+                         **hyperparams: Dict[str, Any]) -> Tuple[bool, str, str]:
         if self._supervised_trainer is None:
             raise ConfigurationException("Trainers are not enabled")
         return self._supervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)

--- a/tests/app/api/test_serving_hf_ner.py
+++ b/tests/app/api/test_serving_hf_ner.py
@@ -44,9 +44,10 @@ def test_train_unsupervised_with_hf_hub_dataset(model_service, client):
         "model_card": None,
     })
     model_service.info.return_value = model_card
+    model_service.train_unsupervised.return_value = (True, "experiment_id", "run_id")
 
     response = client.post("/train_unsupervised_with_hf_hub_dataset?hf_dataset_repo_id=imdb")
 
     model_service.train_unsupervised.assert_called()
     assert response.json()["message"] == "Your training started successfully."
-    assert "training_id" in response.json()
+    assert all([key in response.json() for key in ["training_id", "experiment_id", "run_id"]])


### PR DESCRIPTION
Extend the API to return MLflow tracking information as part of a training or evaluation response, including the experiment and run IDs, and update the tests accordingly. If training is already in progress, the API returns the experiment and run IDs of the current training run. This affects the following routes:
* POST /train_supervised
* POST /train_unsupervised
* POST /train_unsupervised_with_hf_hub_dataset
* POST /train_metacat
* POST /evaluate