### PR TITLE
Docs update for feature summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ To serve NLP models through a container, run the following commands:
 export MODEL_PACKAGE_FULL_PATH=<PATH/TO/MODEL_PACKAGE.zip>
 export CMS_UID=$(id -u $USER)
 export CMS_GID=$(id -g $USER)
+# NOTE: use if you wish to save models locally (i.e run without the mlflow component)
+# export export MLFLOW_TRACKING_URI="file:///tmp/mlruns/"
 docker compose -f docker-compose.yml up -d <model-service>
 ```
 Then the API docs will be accessible at localhost on the mapped port specified in `docker-compose.yml`. The container runs

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The following table summarises the servable model types with their respective ou
 
 The core functionality is provided by services defined in `docker-compose.yml`.
 Additional features generally require running services in extra compose files.
+Most additional services (as well as the core services) require specific environment variables to be set before running.
+See the relevant sections below for details.
 
 | Feature        | Category  |  Additional compose file    |     Feature description                                      |
 |:--------------:|:---------:|:---------------------------:|:------------------------------------------------------------:|

--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ The following table summarises the servable model types with their respective ou
 
 ## Run ModelServe in the container environment:
 
+### Component / feature summary
+
+The core functionality is provided by services defined in `docker-compose.yml`.
+Additional features generally require running services in extra compose files.
+
+| Feature        | Category  |  Additional compose file    |     Feature description                                      |
+|:--------------:|:---------:|:---------------------------:|:------------------------------------------------------------:|
+| Serving        |  Core     |                N/A          | Enables serving the model for inference                      |
+| Evaluating     |  Core     |                N/A          | Enables evaluating model performance                         |
+| Training       | Auxiliary | `docker-compose-mlflow.yml` | Enables model training and lifecycle tracking through MLFlow |
+| Monitoring     | Auxiliary | `docker-compose-mon.yml`    | Enables monitoring the HTTP API usage                        |
+| Logging        | Auxiliary | `docker-compose-log.yml`    | Enable centralised logging and log analysis                  |
+| Proxying       | Auxiliary | `docker-compose-proxy.yml`  | Reverse proxy service                                        |
+| Authentication | Auxiliary | `docker-compose-auth.yml`   | Enable user authentication                                   |
+
 ### Configuration:
 Default configuration properties can be found and customised in `./docker/<MODEL-TYPE>/.envs`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See the relevant sections below for details.
 |:--------------:|:---------:|:---------------------------:|:------------------------------------------------------------:|
 | Serving        |  Core     |                N/A          | Enables serving the model for inference                      |
 | Evaluating     |  Core     |                N/A          | Enables evaluating model performance                         |
-| Training       | Auxiliary | `docker-compose-mlflow.yml` | Enables model training and lifecycle tracking through MLFlow |
+| Training       |  Core     |                N/A          | Enables model training and lifecycle tracking through MLFlow |
 | Monitoring     | Auxiliary | `docker-compose-mon.yml`    | Enables monitoring the HTTP API usage                        |
 | Logging        | Auxiliary | `docker-compose-log.yml`    | Enable centralised logging and log analysis                  |
 | Proxying       | Auxiliary | `docker-compose-proxy.yml`  | Reverse proxy service                                        |


### PR DESCRIPTION
While trying to run the core functionality of CMS, I felt that the documentation wasn't really clear as to which features are enabled by which compose files.

For instance, if I follow the documentation and spin up a service for a Snomed model, I can run inference and evaluation on the model. However, if I try to run training on it, it fails due to not being able to acces MLFlow<sup>1</sup>.
And when I then run the services in `docker-compose-mlflow.yml`, this does work successfully.

As such, this PR suggests an additional summary / overview of the features / functionality and what extra services they may need.

PS: There may be prerequisites I'm not aware of. But this was just be going back and trying to spin up a service that is able to run inference and training on a model. Perhaps there's ways to do this without mlflow, but the documentation does not seem to make it clear.


<sup>1</sup> Exception when trying to train without mlflow:
<details><summary> Failed to resolve 'mlflow-ui' </summary>
The full exception:

```
2025-02-19 15:51:28,198 INFO   [uvicorn.access$send] 172.19.0.1:49876 - "POST /train_unsupervised HTTP/1.1" 500
2025-02-19 15:51:28,198 ERROR  [uvicorn.error$run_asgi] Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/usr/local/lib/python3.10/site-packages/starlette/_utils.py", line 87, in collapse_excgroups
  |     yield
  |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 190, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 767, in __aexit__
  |     raise BaseExceptionGroup(
  | exceptiongroup.ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |   File "/usr/local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 69, in __call__
    |     return await self.app(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/applications.py", line 123, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 186, in __call__
    |     raise exc
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 189, in __call__
    |     with collapse_excgroups():
    |   File "/usr/local/lib/python3.10/contextlib.py", line 153, in __exit__
    |     self.gen.throw(typ, value, traceback)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/_utils.py", line 93, in collapse_excgroups
    |     raise exc
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 191, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |   File "/usr/local/lib/python3.10/site-packages/slowapi/middleware.py", line 136, in dispatch
    |     response = await call_next(request)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 165, in call_next
    |     raise app_exc
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 151, in coro
    |     await self.app(scope, receive_or_disconnect, send_no_error)
    |   File "/usr/local/lib/python3.10/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 155, in __call__
    |     raise exc
    |   File "/usr/local/lib/python3.10/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 153, in __call__
    |     await self.app(scope, receive, send_wrapper)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    |     raise exc
    |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 756, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 776, in app
    |     await route.handle(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 297, in handle
    |     await self.app(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 77, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    |     raise exc
    |   File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 72, in app
    |     response = await func(request)
    |   File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 278, in app
    |     raw_response = await run_endpoint_function(
    |   File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    |     return await dependant.call(**values)
    |   File "/app/api/routers/unsupervised_training.py", line 68, in train_unsupervised
    |     training_response = model_service.train_unsupervised(data_file,
    |   File "/app/model_services/medcat_model.py", line 144, in train_unsupervised
    |     return self._unsupervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)
    |   File "/app/trainers/base.py", line 242, in train
    |     return self.start_training(run=self.run,
    |   File "/app/trainers/base.py", line 73, in start_training
    |     self._experiment_id, self._run_id = self._tracker_client.start_tracking(
    |   File "/app/management/tracker_client.py", line 39, in start_tracking
    |     experiment_id = TrackerClient._get_experiment_id(experiment_name)
    |   File "/app/management/tracker_client.py", line 266, in _get_experiment_id
    |     experiment = mlflow.get_experiment_by_name(experiment_name)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/tracking/fluent.py", line 1616, in get_experiment_by_name
    |     return MlflowClient().get_experiment_by_name(name)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/tracking/client.py", line 1249, in get_experiment_by_name
    |     return self._tracking_client.get_experiment_by_name(name)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/tracking/_tracking_service/client.py", line 484, in get_experiment_by_name
    |     return self.store.get_experiment_by_name(name)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/store/tracking/rest_store.py", line 519, in get_experiment_by_name
    |     response_proto = self._call_endpoint(GetExperimentByName, req_body)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/store/tracking/rest_store.py", line 82, in _call_endpoint
    |     return call_endpoint(self.get_host_creds(), endpoint, method, json_body, response_proto)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/utils/rest_utils.py", line 365, in call_endpoint
    |     response = http_request(**call_kwargs)
    |   File "/usr/local/lib/python3.10/site-packages/mlflow/utils/rest_utils.py", line 212, in http_request
    |     raise MlflowException(f"API request to {url} failed with exception {e}")
    | mlflow.exceptions.MlflowException: API request to http://mlflow-ui:5000/api/2.0/mlflow/experiments/get-by-name failed with exception HTTPConnectionPool(host='mlflow-ui', port=5000): Max retries exceeded with url: /api/2.0/mlflow/experiments/get-by-name?experiment_name=SNOMED_MedCAT_model_unsupervised (Caused by NameResolutionError("<urllib3.connection.HTTPConnection object at 0x7f9c3839efb0>: Failed to resolve 'mlflow-ui' ([Errno -3] Temporary failure in name resolution)"))
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 69, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 189, in __call__
    with collapse_excgroups():
  File "/usr/local/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.10/site-packages/starlette/_utils.py", line 93, in collapse_excgroups
    raise exc
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 191, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/usr/local/lib/python3.10/site-packages/slowapi/middleware.py", line 136, in dispatch
    response = await call_next(request)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 165, in call_next
    raise app_exc
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/base.py", line 151, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/usr/local/lib/python3.10/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 155, in __call__
    raise exc
  File "/usr/local/lib/python3.10/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 153, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/usr/local/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 65, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 756, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 776, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.10/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
  File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.10/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
  File "/app/api/routers/unsupervised_training.py", line 68, in train_unsupervised
    training_response = model_service.train_unsupervised(data_file,
  File "/app/model_services/medcat_model.py", line 144, in train_unsupervised
    return self._unsupervised_trainer.train(data_file, epochs, log_frequency, training_id, input_file_name, raw_data_files, description, synchronised, **hyperparams)
  File "/app/trainers/base.py", line 242, in train
    return self.start_training(run=self.run,
  File "/app/trainers/base.py", line 73, in start_training
    self._experiment_id, self._run_id = self._tracker_client.start_tracking(
  File "/app/management/tracker_client.py", line 39, in start_tracking
    experiment_id = TrackerClient._get_experiment_id(experiment_name)
  File "/app/management/tracker_client.py", line 266, in _get_experiment_id
    experiment = mlflow.get_experiment_by_name(experiment_name)
  File "/usr/local/lib/python3.10/site-packages/mlflow/tracking/fluent.py", line 1616, in get_experiment_by_name
    return MlflowClient().get_experiment_by_name(name)
  File "/usr/local/lib/python3.10/site-packages/mlflow/tracking/client.py", line 1249, in get_experiment_by_name
    return self._tracking_client.get_experiment_by_name(name)
  File "/usr/local/lib/python3.10/site-packages/mlflow/tracking/_tracking_service/client.py", line 484, in get_experiment_by_name
    return self.store.get_experiment_by_name(name)
  File "/usr/local/lib/python3.10/site-packages/mlflow/store/tracking/rest_store.py", line 519, in get_experiment_by_name
    response_proto = self._call_endpoint(GetExperimentByName, req_body)
  File "/usr/local/lib/python3.10/site-packages/mlflow/store/tracking/rest_store.py", line 82, in _call_endpoint
    return call_endpoint(self.get_host_creds(), endpoint, method, json_body, response_proto)
  File "/usr/local/lib/python3.10/site-packages/mlflow/utils/rest_utils.py", line 365, in call_endpoint
    response = http_request(**call_kwargs)
  File "/usr/local/lib/python3.10/site-packages/mlflow/utils/rest_utils.py", line 212, in http_request
    raise MlflowException(f"API request to {url} failed with exception {e}")
mlflow.exceptions.MlflowException: API request to http://mlflow-ui:5000/api/2.0/mlflow/experiments/get-by-name failed with exception HTTPConnectionPool(host='mlflow-ui', port=5000): Max retries exceeded with url: /api/2.0/mlflow/experiments/get-by-name?experiment_name=SNOMED_MedCAT_model_unsupervised (Caused by NameResolutionError("<urllib3.connection.HTTPConnection object at 0x7f9c3839efb0>: Failed to resolve 'mlflow-ui' ([Errno -3] Temporary failure in name resolution)"))

```
</summary>