### PR TITLE
fix: Wait for MinIO Server before creating bucket and catch errors

### DIFF
--- a/docker-compose-mlflow.yml
+++ b/docker-compose-mlflow.yml
@@ -55,8 +55,8 @@ services:
       - MINIO_PASSWORD=$AWS_SECRET_ACCESS_KEY
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc config host add cms_minio http://minio:9000 $${MINIO_USERNAME} $${MINIO_PASSWORD};
-      if ! /usr/bin/mc ls cms_minio/cms-model-bucket 2>/dev/null; then
+      /usr/bin/mc config host add cms_minio http://minio:9000 $${MINIO_USERNAME} $${MINIO_PASSWORD}
+      && if ! /usr/bin/mc ls cms_minio/cms-model-bucket 2>/dev/null; then
         /usr/bin/mc mb cms_minio/cms-model-bucket;
       fi
       "

--- a/docker-compose-mlflow.yml
+++ b/docker-compose-mlflow.yml
@@ -61,7 +61,8 @@ services:
       fi
       "
     depends_on:
-      - minio
+      minio:
+        condition: "service_healthy"
 
   mlflow-ui:
     image: cogstacksystems/cogstack-mlflow-ui:dev


### PR DESCRIPTION
Wait for the MinIO Server to be healthy before attempting to create a bucket as part of the `model-bucket-init` service. This is necessary because the MinIO Server may not be ready to accept requests when the service starts (which is the only thing the default `depends_on` condition guarantees), resulting in errors like the following:

```
Unable to initialize new alias from the provided credentials. Server not initialized, please try again.
```

The above can be seen in [failed integration tests](https://github.com/CogStack/cogstack-model-gateway/actions/runs/13563444874/job/37911130914#step:6:1438) on the Gateway side, while it looks like the change introduced here resolves the issue (subsequent CI runs using this commit to set up CMS [succeed](https://github.com/CogStack/cogstack-model-gateway/actions/runs/13566113774/job/37919520299)).

On top of that, chain the commands involved in creating a MinIO bucket to correctly catch errors and trigger service restarts. Previously, if the first command (i.e. adding a MinIO host) failed, the second one would still run, overwriting the error code and preventing the service from restarting. Using the `&&` operator to chain the commands ensures
that the second command will only run if the first one is successful and that the error code is correctly propagated, allowing Docker to retry in the event of a failure. Note that the MinIO client commands can fail due to a variety of reasons, such as network issues (some of which might be transient), the MinIO Server not being ready, or incorrect credentials.