### PR TITLE
api: Include labels in DeID service model card

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -2,16 +2,16 @@ name: api-docs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
 
     if: |
       github.repository == 'CogStack/CogStack-ModelServe' &&
-      github.ref == 'refs/heads/master' &&
+      github.ref == 'refs/heads/main' &&
       github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
@@ -57,7 +57,7 @@ jobs:
             exit 0
           fi
       - name: Update OpenAPI docs
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@main
         with:
           branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-extra.yaml
+++ b/.github/workflows/docker-extra.yaml
@@ -3,11 +3,11 @@ name: docker extra
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'docker/mlflow/**'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 'docker/mlflow/**'
 
@@ -29,7 +29,7 @@ jobs:
     needs: lint
     if: |
       github.repository == 'CogStack/CogStack-ModelServe' &&
-      github.ref == 'refs/heads/master' &&
+      github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,9 +3,9 @@ name: docker
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   REGISTRY: docker.io
@@ -25,7 +25,7 @@ jobs:
     needs: lint
     if: |
       github.repository == 'CogStack/CogStack-ModelServe' &&
-      github.ref == 'refs/heads/master' &&
+      github.ref == 'refs/heads/main' &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/app/domain.py
+++ b/app/domain.py
@@ -138,6 +138,7 @@ class ModelCard(BaseModel):
     model_type: ModelType = Field(description="The type of the served model")
     model_description: Optional[str] = Field(description="The description about the served model")
     model_card: Optional[dict] = Field(default=None, description="The metadata of the served model")
+    labels: Optional[Dict[str, str]] = Field(default=None, description="The mapping of CUIs to names")
 
 
 class Entity(BaseModel):

--- a/app/model_services/medcat_model_deid.py
+++ b/app/model_services/medcat_model_deid.py
@@ -69,6 +69,7 @@ class MedCATModelDeIdentification(MedCATModel):
             model_type=ModelType.ANONCAT,
             api_version=self.api_version,
             model_card=model_card,
+            labels=self.model.cdb.cui2preferred_name,
         )
 
     def annotate(self, text: str) -> List[Annotation]:

--- a/tests/app/api/test_serving_common.py
+++ b/tests/app/api/test_serving_common.py
@@ -345,6 +345,7 @@ def test_train_unsupervised_with_hf_hub_dataset(model_service, client):
         "model_description": "huggingface_ner_model_description",
         "model_type": ModelType.MEDCAT_SNOMED,
         "model_card": None,
+        "labels": None,
     })
     model_service.info.return_value = model_card
     model_service.train_unsupervised.return_value = (True, "experiment_id", "run_id")

--- a/tests/app/api/test_serving_hf_ner.py
+++ b/tests/app/api/test_serving_hf_ner.py
@@ -42,6 +42,7 @@ def test_train_unsupervised_with_hf_hub_dataset(model_service, client):
         "model_description": "huggingface_ner_model_description",
         "model_type": ModelType.HUGGINGFACE_NER,
         "model_card": None,
+        "labels": None,
     })
     model_service.info.return_value = model_card
     model_service.train_unsupervised.return_value = (True, "experiment_id", "run_id")

--- a/tests/app/api/test_serving_trf.py
+++ b/tests/app/api/test_serving_trf.py
@@ -37,6 +37,7 @@ def test_readyz(model_service, client):
         "model_description": "deid_model_description",
         "model_type": ModelType.TRANSFORMERS_DEID,
         "model_card": None,
+        "labels": None,
     })
     model_service.info.return_value = model_card
 
@@ -49,6 +50,7 @@ def test_info(model_service, client):
         "model_description": "deid_model_description",
         "model_type": ModelType.TRANSFORMERS_DEID,
         "model_card": None,
+        "labels": None,
     })
     model_service.info.return_value = model_card
 


### PR DESCRIPTION
Extend the base model card schema to allow passing a mapping of labels, i.e. concept IDs (e.g. CUIs) to names. This is particularly useful when using the MedCAT model DeID service, which is typically configured to serve models with a relatively small CDB that can be exposed in its entirety as part of the model card. This information can be interesting to the user (or client application), providing insight into the concepts that the model is capable of identifying and by extension enabling them to decide and control which of them should be redacted. The `labels` field is always included in the API's responses when the `/info` endpoint is called, but is only populated with the mapping in a dict format when the CMS instance is configured to use the MedCAT model DeID service.