### PR TITLE
fix: Revert github-push-action branch change

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -57,7 +57,7 @@ jobs:
             exit 0
           fi
       - name: Update OpenAPI docs
-        uses: ad-m/github-push-action@main
+        uses: ad-m/github-push-action@master
         with:
           branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In a previous commit, the branch for the 'github-push-action' in the API docs workflow was accidentally changed from 'master' to 'main', which doesn't exist in the upstream repository. This commit reverts the change to ensure the workflow continues to function correctly.